### PR TITLE
Fixes to CI process.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: arm-none-eabi-gcc
-      uses: fiam/arm-none-eabi-gcc@v1
+    - name: Create directory for ANT keys
+      run: mkdir -p ${{ github.workspace }}/firmware/nRF5_SDK_16.0.0/components/ant/ant_key_manager/config/
+    - name: Create ANT keys
+      uses: RollyPeres/base64-to-path@v1
       with:
-        release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
-        
-    - name: Install srecord
-      run: sudo apt install srecord
+        filePath: ${{ github.workspace }}/firmware/nRF5_SDK_16.0.0/components/ant/ant_key_manager/config/ant_key_manager_config.h
+        encodedString: ${{ secrets.ANT_KEY_MANAGER_CONFIG }}
 
     - name: make
-      run: cd ./firmware && make
+      run: docker run -v $(pwd):/workspace ghcr.io/charliebruce/nrf5-docker-build:sdk-16.0.0 bash -c "cd /workspace/firmware && make"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,5 +10,14 @@ jobs:
         - name: Install cppcheck
           run: sudo apt-get -y install cppcheck
         - uses: actions/checkout@v2
+
+        - name: Create directory for ANT keys
+          run: mkdir -p ${{ github.workspace }}/firmware/nRF5_SDK_16.0.0/components/ant/ant_key_manager/config/
+        - name: Create ANT keys
+          uses: RollyPeres/base64-to-path@v1
+          with:
+            filePath: ${{ github.workspace }}/firmware/nRF5_SDK_16.0.0/components/ant/ant_key_manager/config/ant_key_manager_config.h
+            encodedString: ${{ secrets.ANT_KEY_MANAGER_CONFIG }}
+
         - name: "Run cppcheck"
           run: cppcheck --enable=all --error-exitcode=1 -ifirmware/nRF5_SDK_16.0.0 firmware/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,21 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - name: arm-none-eabi-gcc
-        uses: fiam/arm-none-eabi-gcc@v1
-        with:
-          release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
-
-      - name: Install srecord
-        run: sudo apt install srecord
-      
+       
       - id: get_version
         uses: battila7/get-version-action@v2
       - run: echo ${{ steps.get_version.outputs.version }}
+
+      - name: Create directory for ANT keys
+        run: mkdir -p ${{ github.workspace }}/firmware/nRF5_SDK_16.0.0/components/ant/ant_key_manager/config/
+      - name: Create ANT keys
+        uses: RollyPeres/base64-to-path@v1
+        with:
+          filePath: ${{ github.workspace }}/firmware/nRF5_SDK_16.0.0/components/ant/ant_key_manager/config/ant_key_manager_config.h
+          encodedString: ${{ secrets.ANT_KEY_MANAGER_CONFIG }}
         
-      - name: Build project # This would actually build your project, using zip for an example artifact
-        run: cd ./firmware && make
+      - name: make
+        run: docker run -v $(pwd):/workspace ghcr.io/charliebruce/nrf5-docker-build:sdk-16.0.0 bash -c "cd /workspace/firmware && make"
         
       - name: Create Release
         id: create_release

--- a/firmware/nRF5_SDK_16.0.0/components/toolchain/gcc/Makefile.posix
+++ b/firmware/nRF5_SDK_16.0.0/components/toolchain/gcc/Makefile.posix
@@ -1,7 +1,3 @@
-#GNU_INSTALL_ROOT ?= /usr/local/gcc-arm-none-eabi-7-2018-q2-update/bin/
-#GNU_VERSION ?= 7.3.1
-#GNU_PREFIX ?= arm-none-eabi
-
-#GNU_INSTALL_ROOT := /usr/local/gcc-arm-none-eabi-4_9-2015q3
-GNU_VERSION := 4.9.3
-GNU_PREFIX := arm-none-eabi
+GNU_INSTALL_ROOT ?= /usr/local/gcc-arm-none-eabi-7-2018-q2-update/bin/
+GNU_VERSION ?= 7.3.1
+GNU_PREFIX ?= arm-none-eabi


### PR DESCRIPTION
This PR will hopefully get the build process near to working. I believe the only issue now is the missing file `./include/TSDZ2_bootloader_with_sd.hex`. I'm not sure how you want to manage your hex files so I don't know the best solution.

You can encode your keys file with:

```openssl base64 -in nRF5_SDK_16.0.0/components/ant/ant_key_manager/ant_key_manager_config.h -out my_encoded_secret```

You'll then need to add the contents of `my_encoded_secret` file to the repo as a secret named `ANT_KEY_MANAGER_CONFIG`. I've tested this on my fork with the SDK default (all-zero) header.

Fixes #9 once the above is done.

A few notes:
* This uses a Docker image to build, with srecord, nrfutils, arm-none-eabi-gcc pre-installed.
* This changes the gcc toolchain back to `gcc-arm-none-eabi-7-2018-q2-update` (Nordic's suggested version) - don't know if you had a specific reason for using the older version?
* This only builds the app, not bootloader. Would be a quick fix, but need to fix the GCC toolchain version in the sub-repo too.

Longer-term, you might want to look at my [template project](https://github.com/charliebruce/nrf5-example-project). There are some advantages:
* Faster builds (multithreaded)
* Smaller checkouts (the SDK is part of the Docker environment, does not need to be part of the repo)
* Local builds use the same environment as CI builds (compilation all happens within a Docker environment, started up transparently by the Makefile).
* Hardware versioning

These scripts aren't a straightforward swap though - looks like you've modified the Makefiles and possibly also applied some patches to the SDK?